### PR TITLE
Adjust the reported output filepath

### DIFF
--- a/compass/services/threaded.py
+++ b/compass/services/threaded.py
@@ -646,7 +646,7 @@ def _dump_jurisdiction_info(
 def _compile_doc_info(doc):
     """Put together meta information about a single document"""
     year, month, day = doc.attrs.get("date") or (None, None, None)
-    out_fp = doc.attrs.get("source_fp", doc.attrs.get("out_fp"))
+    out_fp = doc.attrs.get("out_fp", doc.attrs.get("source_fp"))
     return {
         "source": doc.attrs.get("source"),
         "effective_year": year if year is not None and year > 0 else None,

--- a/compass/services/threaded.py
+++ b/compass/services/threaded.py
@@ -646,7 +646,7 @@ def _dump_jurisdiction_info(
 def _compile_doc_info(doc):
     """Put together meta information about a single document"""
     year, month, day = doc.attrs.get("date") or (None, None, None)
-    out_fp = doc.attrs.get("out_fp", doc.attrs.get("source_fp"))
+    out_fp = doc.attrs.get("out_fp") or doc.attrs.get("source_fp")
     return {
         "source": doc.attrs.get("source"),
         "effective_year": year if year is not None and year > 0 else None,

--- a/tests/python/unit/extraction/test_extraction_context.py
+++ b/tests/python/unit/extraction/test_extraction_context.py
@@ -294,7 +294,7 @@ async def test_mark_doc_as_data_source_no_file_move():
 @pytest.mark.asyncio
 async def test_mark_doc_as_data_source_with_file_move(monkeypatch, tmp_path):
     """Test marking document with file moving"""
-    out_file = tmp_path / "output.pdf"
+    out_file = tmp_path / "extraction" / "output.pdf"
 
     async def fake_file_mover(doc_arg, out_fn):  # ruff:ignore[unused-async]
         assert out_fn == "output.pdf"
@@ -316,7 +316,7 @@ async def test_mark_doc_as_data_source_with_file_move(monkeypatch, tmp_path):
 @pytest.mark.asyncio
 async def test_move_file_to_out_dir(monkeypatch, tmp_path):
     """Test _move_file_to_out_dir helper"""
-    output_path = tmp_path / "moved.pdf"
+    output_path = tmp_path / "extraction" / "moved.pdf"
 
     async def fake_mover(doc_arg, out_fn):  # ruff:ignore[unused-async]
         assert out_fn == "output_name.pdf"

--- a/tests/python/unit/services/test_services_threaded.py
+++ b/tests/python/unit/services/test_services_threaded.py
@@ -582,6 +582,22 @@ async def test_jurisdiction_updater_process(tmp_path):
     updater.release_resources()
 
 
+def test_compile_doc_info_prefers_output_file_path(tmp_path):
+    """Document info should use final output path for its filename"""
+
+    doc = HTMLDocument(["page"])
+    doc.attrs.update(
+        {
+            "source_fp": tmp_path / "source.pdf",
+            "out_fp": tmp_path / "processed.pdf",
+        }
+    )
+
+    doc_info = threaded._compile_doc_info(doc)
+
+    assert doc_info["ord_filename"] == "processed.pdf"
+
+
 def test_dump_usage_without_tracker_returns_existing_data(tmp_path):
     """_dump_usage should return existing data unchanged when tracker absent"""
 

--- a/tests/python/unit/services/test_services_threaded.py
+++ b/tests/python/unit/services/test_services_threaded.py
@@ -598,6 +598,24 @@ def test_compile_doc_info_prefers_output_file_path(tmp_path):
     assert doc_info["ord_filename"] == "processed.pdf"
 
 
+def test_compile_doc_info_uses_source_path_when_output_path_is_none(
+    tmp_path,
+):
+    """Document info should fall back to source path when needed"""
+
+    doc = HTMLDocument(["page"])
+    doc.attrs.update(
+        {
+            "source_fp": tmp_path / "source.pdf",
+            "out_fp": None,
+        }
+    )
+
+    doc_info = threaded._compile_doc_info(doc)
+
+    assert doc_info["ord_filename"] == "source.pdf"
+
+
 def test_dump_usage_without_tracker_returns_existing_data(tmp_path):
     """_dump_usage should return existing data unchanged when tracker absent"""
 


### PR DESCRIPTION
Previously, when running extraction after the collection step, the document filename that was reported out pertained to the collection file path. In this update, we switch the priority so that the extraction file path is reported first for better consistency in outputs