### PR TITLE
Allow website in query tempaltes

### DIFF
--- a/compass/web/search.py
+++ b/compass/web/search.py
@@ -25,7 +25,10 @@ async def search_single_jurisdiction(
     query_templates : iterable of str
         Query templates to format with the jurisdiction name and search.
         Each template should include a ``{jurisdiction}`` placeholder
-        for the jurisdiction name.
+        for the jurisdiction name. Templates may include a
+        ``{jurisdiction_website}`` placeholder for the jurisdiction's
+        known website URL. Website templates are skipped when the
+        jurisdiction does not have a known website.
     jurisdiction : Jurisdiction
         Jurisdiction instance representing the jurisdiction to search
         documents for.
@@ -72,8 +75,12 @@ async def search_single_jurisdiction(
     """
 
     queries = [
-        query.format(jurisdiction=jurisdiction.full_name)
+        query.format(
+            jurisdiction=jurisdiction.full_name,
+            jurisdiction_website=jurisdiction.website_url,
+        )
         for query in query_templates
+        if "{jurisdiction_website}" not in query or jurisdiction.website_url
     ]
     base = {
         "jurisdiction": jurisdiction.full_name,

--- a/compass/web/search.py
+++ b/compass/web/search.py
@@ -1,11 +1,13 @@
 """COMPASS ordinance document web search functionality"""
 
 import logging
+from urllib.parse import urlsplit, urlunsplit
 
 from elm.web.search.run import search_with_fallback, search_all_se
 
 
 logger = logging.getLogger(__name__)
+_JURISDICTION_WEBSITE_PLACEHOLDER = "{jurisdiction_website}"
 
 
 async def search_single_jurisdiction(
@@ -74,14 +76,7 @@ async def search_single_jurisdiction(
 
     """
 
-    queries = [
-        query.format(
-            jurisdiction=jurisdiction.full_name,
-            jurisdiction_website=jurisdiction.website_url,
-        )
-        for query in query_templates
-        if "{jurisdiction_website}" not in query or jurisdiction.website_url
-    ]
+    queries = _format_queries(jurisdiction, query_templates)
     base = {
         "jurisdiction": jurisdiction.full_name,
         "state": jurisdiction.state,
@@ -91,6 +86,9 @@ async def search_single_jurisdiction(
         "results": [],
         "error": None,
     }
+    if not queries:
+        return base
+
     run_meth = _run_simple_sort_search if simple else _run_holistic_sort_search
 
     try:
@@ -111,6 +109,33 @@ async def search_single_jurisdiction(
 
     base["results"] = out
     return base
+
+
+def _format_queries(jurisdiction, query_templates):
+    """Format query templates for a given jurisdiction"""
+    jurisdiction_website = _format_jurisdiction_website(jurisdiction)
+    return [
+        query.format(
+            jurisdiction=jurisdiction.full_name,
+            jurisdiction_website=jurisdiction_website,
+        )
+        for query in query_templates
+        if _JURISDICTION_WEBSITE_PLACEHOLDER not in query
+        or jurisdiction.website_url
+    ]
+
+
+def _format_jurisdiction_website(jurisdiction):
+    """Strip paths and ensure a valid URL scheme for a jur website"""
+    jurisdiction_website = jurisdiction.website_url
+    if jurisdiction_website:
+        website_parts = urlsplit(jurisdiction_website)
+        if not website_parts.netloc:
+            website_parts = urlsplit(f"//{jurisdiction_website}")
+        jurisdiction_website = urlunsplit(
+            (website_parts.scheme, website_parts.netloc, "", "", "")
+        ).removeprefix("//")
+    return jurisdiction_website
 
 
 async def _run_simple_sort_search(

--- a/docs/source/dev/advanced_plugin_development.rst
+++ b/docs/source/dev/advanced_plugin_development.rst
@@ -173,7 +173,10 @@ The contract
 ``BaseExtractionPlugin`` requires you to implement:
 
 ``get_query_templates()``
-  Return list of search query templates for document discovery.
+    Return a list of search query templates for document discovery. Use
+    ``{jurisdiction}`` for the jurisdiction's full name. A template may use
+    ``{jurisdiction_website}`` for the known jurisdiction website URL;
+    COMPASS discards that template when no website is known.
 
 ``get_website_keywords()``
   Return dict of keywords→priority for web crawling.

--- a/docs/source/dev/plugin_development.rst
+++ b/docs/source/dev/plugin_development.rst
@@ -255,6 +255,7 @@ this pipeline."
            "battery energy storage ordinance {jurisdiction}",
            "{jurisdiction} battery storage regulations",
            "{jurisdiction} BESS zoning",
+           "site:{jurisdiction_website} battery storage ordinance",
        ]
 
        WEBSITE_KEYWORDS = {
@@ -272,6 +273,13 @@ this pipeline."
        PARSERS = [BatteryStorageParser]
 
    register_plugin(BatteryStorageExtractor)
+
+Query templates must use ``{jurisdiction}`` where the jurisdiction's full
+name should appear. They may also use the exact placeholder
+``{jurisdiction_website}`` to restrict a query to the jurisdiction's known
+website, as shown by the ``site:`` query above. COMPASS submits templates
+containing this website placeholder only when the jurisdiction has a known
+website URL; otherwise, it discards those templates before searching.
 
 Step 6: Run it
 --------------

--- a/tests/python/unit/web/test_web_search.py
+++ b/tests/python/unit/web/test_web_search.py
@@ -5,6 +5,73 @@ from pathlib import Path
 import pytest
 
 import compass.web.search as search_module
+from compass.utilities.jurisdictions import Jurisdiction
+
+
+@pytest.mark.asyncio
+async def test_search_formats_query_with_known_jurisdiction_website(
+    monkeypatch,
+):
+    """Include website query when the jurisdiction website is known"""
+    submitted_queries = None
+
+    async def capture_queries(queries, *args, **kwargs):
+        nonlocal submitted_queries
+        submitted_queries = queries
+        return []
+
+    monkeypatch.setattr(
+        search_module, "_run_simple_sort_search", capture_queries
+    )
+    jurisdiction = Jurisdiction(
+        "county",
+        "Colorado",
+        county="Adams",
+        website_url="https://www.adcogov.org",
+    )
+    query_templates = [
+        "{jurisdiction} zoning ordinance",
+        "site:{jurisdiction_website} zoning ordinance",
+    ]
+
+    output = await search_module.search_single_jurisdiction(
+        query_templates, jurisdiction
+    )
+
+    assert submitted_queries == [
+        "Adams County, Colorado zoning ordinance",
+        "site:https://www.adcogov.org zoning ordinance",
+    ]
+    assert output["queries"] == submitted_queries
+
+
+@pytest.mark.asyncio
+async def test_search_discards_website_query_without_known_website(
+    monkeypatch,
+):
+    """Discard website query when the jurisdiction website is unknown"""
+    submitted_queries = None
+
+    async def capture_queries(queries, *args, **kwargs):
+        nonlocal submitted_queries
+        submitted_queries = queries
+        return []
+
+    monkeypatch.setattr(
+        search_module, "_run_simple_sort_search", capture_queries
+    )
+    jurisdiction = Jurisdiction("county", "Colorado", county="Adams")
+    query_templates = [
+        "{jurisdiction} zoning ordinance",
+        "site:{jurisdiction_website} zoning ordinance",
+    ]
+
+    output = await search_module.search_single_jurisdiction(
+        query_templates, jurisdiction
+    )
+
+    assert submitted_queries == ["Adams County, Colorado zoning ordinance"]
+    assert output["queries"] == submitted_queries
 
 
 def test_apply_blacklist_filters_is_case_insensitive():

--- a/tests/python/unit/web/test_web_search.py
+++ b/tests/python/unit/web/test_web_search.py
@@ -1,6 +1,7 @@
 """Tests for compass.scripts.search"""
 
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -8,36 +9,35 @@ import compass.web.search as search_module
 from compass.utilities.jurisdictions import Jurisdiction
 
 
+_JURISDICTION_QUERY_TEMPLATE = "{jurisdiction} zoning ordinance"
+_WEBSITE_QUERY_TEMPLATE = "site:{jurisdiction_website} zoning ordinance"
+
+
 @pytest.mark.asyncio
 async def test_search_formats_query_with_known_jurisdiction_website(
     monkeypatch,
 ):
     """Include website query when the jurisdiction website is known"""
-    submitted_queries = None
-
-    async def capture_queries(queries, *args, **kwargs):
-        nonlocal submitted_queries
-        submitted_queries = queries
-        return []
-
+    search_backend = AsyncMock(return_value=[])
     monkeypatch.setattr(
-        search_module, "_run_simple_sort_search", capture_queries
+        search_module, "_run_simple_sort_search", search_backend
     )
     jurisdiction = Jurisdiction(
         "county",
         "Colorado",
         county="Adams",
-        website_url="https://www.adcogov.org",
+        website_url="https://www.adcogov.org/government?lang=en#offices",
     )
     query_templates = [
-        "{jurisdiction} zoning ordinance",
-        "site:{jurisdiction_website} zoning ordinance",
+        _JURISDICTION_QUERY_TEMPLATE,
+        _WEBSITE_QUERY_TEMPLATE,
     ]
 
     output = await search_module.search_single_jurisdiction(
         query_templates, jurisdiction
     )
 
+    submitted_queries = search_backend.await_args.args[0]
     assert submitted_queries == [
         "Adams County, Colorado zoning ordinance",
         "site:https://www.adcogov.org zoning ordinance",
@@ -50,28 +50,64 @@ async def test_search_discards_website_query_without_known_website(
     monkeypatch,
 ):
     """Discard website query when the jurisdiction website is unknown"""
-    submitted_queries = None
-
-    async def capture_queries(queries, *args, **kwargs):
-        nonlocal submitted_queries
-        submitted_queries = queries
-        return []
-
+    search_backend = AsyncMock(return_value=[])
     monkeypatch.setattr(
-        search_module, "_run_simple_sort_search", capture_queries
+        search_module, "_run_simple_sort_search", search_backend
     )
     jurisdiction = Jurisdiction("county", "Colorado", county="Adams")
     query_templates = [
-        "{jurisdiction} zoning ordinance",
-        "site:{jurisdiction_website} zoning ordinance",
+        _JURISDICTION_QUERY_TEMPLATE,
+        _WEBSITE_QUERY_TEMPLATE,
     ]
 
     output = await search_module.search_single_jurisdiction(
         query_templates, jurisdiction
     )
 
+    submitted_queries = search_backend.await_args.args[0]
     assert submitted_queries == ["Adams County, Colorado zoning ordinance"]
     assert output["queries"] == submitted_queries
+
+
+@pytest.mark.asyncio
+async def test_search_skips_backend_when_no_queries_remain(monkeypatch):
+    """Return an empty result when all query templates are discarded"""
+    search_backend = AsyncMock()
+    monkeypatch.setattr(
+        search_module, "_run_simple_sort_search", search_backend
+    )
+    jurisdiction = Jurisdiction("county", "Colorado", county="Adams")
+
+    output = await search_module.search_single_jurisdiction(
+        [_WEBSITE_QUERY_TEMPLATE], jurisdiction
+    )
+
+    search_backend.assert_not_awaited()
+    assert output["queries"] == []
+    assert output["results"] == []
+    assert output["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_search_formats_bare_jurisdiction_website(monkeypatch):
+    """Strip paths from jurisdiction websites without a URL scheme"""
+    search_backend = AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        search_module, "_run_simple_sort_search", search_backend
+    )
+    jurisdiction = Jurisdiction(
+        "county",
+        "Colorado",
+        county="Adams",
+        website_url="www.adcogov.org/government?lang=en#offices",
+    )
+
+    await search_module.search_single_jurisdiction(
+        [_WEBSITE_QUERY_TEMPLATE], jurisdiction
+    )
+
+    submitted_queries = search_backend.await_args.args[0]
+    assert submitted_queries == ["site:www.adcogov.org zoning ordinance"]
 
 
 def test_apply_blacklist_filters_is_case_insensitive():


### PR DESCRIPTION
Allow user to specify a jurisdiction website in the query templates, which would only get filled in and used if the jurisdiction has a known website